### PR TITLE
Persist socket reconnect context across reloads

### DIFF
--- a/client/src/components/ShareRoom.tsx
+++ b/client/src/components/ShareRoom.tsx
@@ -12,6 +12,12 @@ const ShareRoom: React.FC<ShareRoomProps> = ({ room, shareUrl, onShare }) => (
     <div style={{ fontSize: 12, color: "#888" }}>
       or share code: <b>{room}</b>
     </div>
+    <div style={{ fontSize: 12, color: "#888", marginTop: 4 }}>
+      link: {" "}
+      <a href={shareUrl} target="_blank" rel="noreferrer">
+        {shareUrl}
+      </a>
+    </div>
   </div>
 );
 

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -1,11 +1,27 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { io, Socket } from "socket.io-client";
-import type { Player, GameEndData, GuessResult, StartGameData } from "../types";
+import type {
+  Player,
+  GameEndData,
+  GuessResult,
+  RoomStatePayload,
+  StartGameData,
+} from "../types";
 
 const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || "http://localhost:3001";
 
+const STORAGE_KEY = "connect8:lastJoinDetails";
+
+type JoinDetails = { room: string; name: string; lastSocketId: string | null };
+type PendingJoin = { room: string; name: string; previousSocketId?: string };
+
 export function useSocket(room: string, name: string) {
-  const [socket] = useState<Socket>(() => io(SOCKET_URL));
+  const [socket] = useState<Socket>(() =>
+    io(SOCKET_URL, {
+      autoConnect: false,
+      reconnection: true,
+    })
+  );
   const [players, setPlayers] = useState<Player[]>([]);
   const [confirmedPlayers, setConfirmedPlayers] = useState<string[]>([]);
   const [gameStarted, setGameStarted] = useState(false);
@@ -15,6 +31,34 @@ export function useSocket(room: string, name: string) {
   const [wrongGuesses, setWrongGuesses] = useState<string[]>([]);
   const [winner, setWinner] = useState<string | null>(null);
   const [finalWords, setFinalWords] = useState<GameEndData["players"]>([]);
+
+  const lastJoinDetailsRef = useRef<JoinDetails | null>(null);
+  const pendingJoinRef = useRef<PendingJoin | null>(null);
+  const hasAttemptedStoredReconnectRef = useRef(false);
+
+  const persistJoinDetails = useCallback(() => {
+    const details = lastJoinDetailsRef.current;
+    if (typeof window === "undefined") return;
+    if (details) {
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(details));
+    } else {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedJoinDetails = window.sessionStorage.getItem(STORAGE_KEY);
+    if (storedJoinDetails) {
+      try {
+        lastJoinDetailsRef.current = JSON.parse(storedJoinDetails) as JoinDetails;
+      } catch (error) {
+        console.warn("Failed to parse stored join details", error);
+        window.sessionStorage.removeItem(STORAGE_KEY);
+        lastJoinDetailsRef.current = null;
+      }
+    }
+  }, []);
 
   useEffect(() => {
     socket.on("players_updated", setPlayers);
@@ -53,6 +97,96 @@ export function useSocket(room: string, name: string) {
       setWinner(null);
       setFinalWords([]);
     });
+    const emitJoin = ({
+      roomCode,
+      playerName,
+      previousSocketId,
+    }: {
+      roomCode: string;
+      playerName: string;
+      previousSocketId?: string;
+    }) => {
+      const sanitizedPreviousId =
+        previousSocketId && previousSocketId !== (socket.id ?? "")
+          ? previousSocketId
+          : undefined;
+      socket.emit("join_room", {
+        roomCode,
+        playerName,
+        previousSocketId: sanitizedPreviousId,
+      });
+    };
+
+    const handleConnect = () => {
+      const lastJoinDetails = lastJoinDetailsRef.current;
+      const pendingJoin = pendingJoinRef.current;
+
+      if (pendingJoin) {
+        emitJoin({
+          roomCode: pendingJoin.room,
+          playerName: pendingJoin.name,
+          previousSocketId: pendingJoin.previousSocketId,
+        });
+        pendingJoinRef.current = null;
+      } else if (lastJoinDetails) {
+        emitJoin({
+          roomCode: lastJoinDetails.room,
+          playerName: lastJoinDetails.name,
+          previousSocketId: lastJoinDetails.lastSocketId ?? undefined,
+        });
+      }
+
+      if (lastJoinDetails) {
+        lastJoinDetails.lastSocketId = socket.id ?? null;
+        persistJoinDetails();
+      }
+    };
+    const handleVisibilityChange = () => {
+      if (
+        document.visibilityState === "visible" &&
+        socket.disconnected &&
+        (pendingJoinRef.current || lastJoinDetailsRef.current)
+      ) {
+        socket.connect();
+      }
+    };
+    const handleRoomState = (state: RoomStatePayload) => {
+      setPlayers(state.players);
+      setConfirmedPlayers(state.confirmedPlayers);
+      setWrongGuesses(state.wrongGuesses);
+      setWinner(state.winner);
+      setFinalWords(state.finalWords);
+      if (state.gameStarted) {
+        setGameStarted(true);
+        const opponent = state.players.find((p) => p.id !== (socket.id ?? ""));
+        const opponentId = opponent?.id ?? "";
+        setOpponentWords(state.playerWords[opponentId] || []);
+        setGuessedWords(state.revealedWords[opponentId] || []);
+        setCurrentTurn(state.currentTurn);
+      } else {
+        setGameStarted(false);
+        setCurrentTurn(state.currentTurn || "");
+        if (!state.winner) {
+          setOpponentWords([]);
+          setGuessedWords([]);
+        }
+      }
+    };
+    const handleDisconnect = () => {
+      if (lastJoinDetailsRef.current) {
+        lastJoinDetailsRef.current.lastSocketId = socket.id ?? null;
+        persistJoinDetails();
+        if (socket.disconnected && document.visibilityState === "visible") {
+          socket.connect();
+        }
+      }
+    };
+
+    socket.on("connect", handleConnect);
+    socket.on("disconnect", handleDisconnect);
+    socket.on("room_state", handleRoomState);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
     return () => {
       socket.off("players_updated");
       socket.off("player_confirmed");
@@ -60,13 +194,52 @@ export function useSocket(room: string, name: string) {
       socket.off("guess_result");
       socket.off("game_end");
       socket.off("game_reset");
+      socket.off("connect", handleConnect);
+      socket.off("disconnect", handleDisconnect);
+      socket.off("room_state", handleRoomState);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
+  }, [persistJoinDetails, socket]);
+
+  useEffect(() => {
+    if (hasAttemptedStoredReconnectRef.current) return;
+    hasAttemptedStoredReconnectRef.current = true;
+    if (socket.disconnected && lastJoinDetailsRef.current) {
+      socket.connect();
+    }
   }, [socket]);
 
   const joinRoom = useCallback(() => {
     if (!name || !room) return;
-    socket.emit("join_room", { roomCode: room, playerName: name });
-  }, [name, room, socket]);
+    const previousSocketId = lastJoinDetailsRef.current?.lastSocketId ?? undefined;
+    const sanitizedPreviousId =
+      previousSocketId && previousSocketId !== (socket.id ?? "")
+        ? previousSocketId
+        : undefined;
+
+    lastJoinDetailsRef.current = {
+      room,
+      name,
+      lastSocketId: socket.id ?? null,
+    };
+    persistJoinDetails();
+
+    if (socket.connected) {
+      socket.emit("join_room", {
+        roomCode: room,
+        playerName: name,
+        previousSocketId: sanitizedPreviousId,
+      });
+      pendingJoinRef.current = null;
+    } else {
+      pendingJoinRef.current = {
+        room,
+        name,
+        previousSocketId: sanitizedPreviousId,
+      };
+      socket.connect();
+    }
+  }, [name, persistJoinDetails, room, socket]);
 
   return {
     socket,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,6 +2,7 @@ export interface Player {
   id: string;
   name: string;
   words?: string[];
+  connected?: boolean;
 }
 
 export interface GameEndData {
@@ -32,4 +33,16 @@ export interface GameState {
   myWordsLeft: string[];
   opponentWordsLeft: RevealedWord[];
   isMyTurn: boolean;
+}
+
+export interface RoomStatePayload {
+  players: Player[];
+  confirmedPlayers: string[];
+  gameStarted: boolean;
+  currentTurn: string;
+  playerWords: Record<string, string[]>;
+  revealedWords: Record<string, number[]>;
+  wrongGuesses: string[];
+  winner: string | null;
+  finalWords: { id: string; words: string[] }[];
 }


### PR DESCRIPTION
## Summary
- persist the last successful room join details in sessionStorage so reconnect attempts survive visibility changes and reloads
- remember the most recent socket id on disconnect/connect cycles to automatically rejoin the prior room
- keep disconnected players in the room roster while marking them offline so room snapshots retain their game state during reconnection
- queue join_room emissions until the socket has reconnected and only trigger reconnect attempts when stored join context exists to avoid duplicate joins

## Testing
- npm --prefix client run build
- npm --prefix server run build

------
https://chatgpt.com/codex/tasks/task_e_68d70648e974832c923e6f75a4bc4168