### PR TITLE
Add pagination to puzzles and reposition home button

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -53,6 +53,19 @@ export const Home: React.FC = () => {
             </button>
           </div>
 
+          {/* View All Puzzles */}
+          <Link to="/puzzles" className="block group">
+            <Card hoverEffect className="flex flex-col sm:flex-row items-center justify-between p-8 bg-neo-secondary border-4 border-black gap-4 text-center sm:text-left">
+              <div className="flex items-center gap-4">
+                <Grid className="h-8 w-8" />
+                <h2 className="text-2xl font-black uppercase">View All Puzzles</h2>
+              </div>
+              <span className="font-bold uppercase group-hover:underline decoration-4 underline-offset-4 text-sm sm:text-base">
+                Browse Archive &rarr;
+              </span>
+            </Card>
+          </Link>
+
           {/* How to Play */}
           <Card className="border-4 border-black p-8 bg-white">
             <div className="flex items-center gap-4 mb-6">
@@ -75,19 +88,6 @@ export const Home: React.FC = () => {
               </div>
             </div>
           </Card>
-
-          {/* View All Puzzles */}
-          <Link to="/puzzles" className="block group">
-            <Card hoverEffect className="flex items-center justify-between p-8 bg-neo-secondary border-4 border-black">
-              <div className="flex items-center gap-4">
-                <Grid className="h-8 w-8" />
-                <h2 className="text-2xl font-black uppercase">View All Puzzles</h2>
-              </div>
-              <span className="font-bold uppercase group-hover:underline decoration-4 underline-offset-4">
-                Browse Archive &rarr;
-              </span>
-            </Card>
-          </Link>
 
         </div>
       </Container>

--- a/client/src/pages/WordSetList.tsx
+++ b/client/src/pages/WordSetList.tsx
@@ -1,18 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { getWordSets } from '../services/api';
 import { Header } from '../components/Header';
 import { Container } from '../components/ui/Container';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
 
 export const WordSetList: React.FC = () => {
-  const { data: wordSets = [], isLoading: loading, isError } = useQuery({
-    queryKey: ['wordSets'],
-    queryFn: getWordSets,
+  const [page, setPage] = useState(1);
+  const limit = 9;
+
+  const { data, isLoading: loading, isError } = useQuery({
+    queryKey: ['wordSets', page],
+    queryFn: () => getWordSets(page, limit),
+    placeholderData: keepPreviousData,
   });
+
+  const wordSets = data?.data || [];
+  const totalPages = data?.meta.totalPages || 0;
 
   return (
     <div className="min-h-screen bg-neo-bg">
@@ -75,6 +83,29 @@ export const WordSetList: React.FC = () => {
 
         {!loading && wordSets.length === 0 && !isError && (
             <div className="text-center text-gray-500 font-bold uppercase mt-12">No word sets available.</div>
+        )}
+
+        {/* Pagination Controls */}
+        {!loading && !isError && totalPages > 1 && (
+          <div className="mt-12 flex justify-center items-center gap-4">
+            <button
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="p-2 border-2 border-black bg-white shadow-neo-sm hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none active:translate-x-[4px] active:translate-y-[4px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="h-6 w-6" />
+            </button>
+            <span className="font-bold uppercase">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="p-2 border-2 border-black bg-white shadow-neo-sm hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none active:translate-x-[4px] active:translate-y-[4px] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="h-6 w-6" />
+            </button>
+          </div>
         )}
       </Container>
     </div>

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -7,12 +7,20 @@ const api = axios.create({
   baseURL: `${API_URL}/api`
 });
 
-export const getWordSets = async (): Promise<WordSetSummary[]> => {
-  const response = await api.get<WordSetSummary[]>('/word-sets');
-  if (!Array.isArray(response.data)) {
-    console.error('getWordSets: Expected array but received:', response.data);
-    return [];
-  }
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export const getWordSets = async (page: number = 1, limit: number = 9): Promise<PaginatedResponse<WordSetSummary>> => {
+  const response = await api.get<PaginatedResponse<WordSetSummary>>('/word-sets', {
+    params: { page, limit }
+  });
   return response.data;
 };
 

--- a/server/src/models/wordSet.ts
+++ b/server/src/models/wordSet.ts
@@ -14,10 +14,20 @@ export interface WordSetSummary {
   published_at: Date | null;
 }
 
-export const findAll = async (): Promise<WordSetSummary[]> => {
-  const text = 'SELECT id, title, published_at FROM word_sets ORDER BY published_at DESC';
-  const result = await query<WordSetSummary>(text);
-  return result.rows;
+export const findAll = async (page: number = 1, limit: number = 10): Promise<{ wordSets: WordSetSummary[], total: number }> => {
+  const offset = (page - 1) * limit;
+  const text = 'SELECT id, title, published_at FROM word_sets ORDER BY published_at DESC LIMIT $1 OFFSET $2';
+  const countText = 'SELECT COUNT(*) FROM word_sets';
+
+  const [result, countResult] = await Promise.all([
+    query<WordSetSummary>(text, [limit, offset]),
+    query<{ count: string }>(countText)
+  ]);
+
+  return {
+    wordSets: result.rows,
+    total: parseInt(countResult.rows[0].count, 10)
+  };
 };
 
 export const findById = async (id: number): Promise<WordSet | null> => {

--- a/server/src/routes/wordSets.ts
+++ b/server/src/routes/wordSets.ts
@@ -5,8 +5,20 @@ const router = Router();
 
 router.get('/', async (req: Request, res: Response) => {
   try {
-    const wordSets = await WordSetModel.findAll();
-    res.json(wordSets);
+    const page = parseInt(req.query.page as string) || 1;
+    const limit = parseInt(req.query.limit as string) || 10;
+
+    const { wordSets, total } = await WordSetModel.findAll(page, limit);
+
+    res.json({
+      data: wordSets,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit)
+      }
+    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Internal Server Error' });

--- a/server/src/tests/api.test.ts
+++ b/server/src/tests/api.test.ts
@@ -26,16 +26,20 @@ describe('Word Sets API', () => {
   });
 
   describe('GET /api/word-sets', () => {
-    it('should return a list of word sets', async () => {
-      mockedWordSetModel.findAll.mockResolvedValue(mockWordSets);
+    it('should return a paginated list of word sets', async () => {
+      mockedWordSetModel.findAll.mockResolvedValue({
+        wordSets: mockWordSets,
+        total: 2
+      });
 
       const res = await request(app).get('/api/word-sets');
 
       expect(res.status).toBe(200);
-      expect(res.body).toHaveLength(2);
-      expect(res.body[0].title).toBe('Test Set 1');
+      expect(res.body.data).toHaveLength(2);
+      expect(res.body.meta.total).toBe(2);
+      expect(res.body.data[0].title).toBe('Test Set 1');
       // Date is serialized to string in JSON
-      expect(res.body[0].published_at).toBe(mockWordSets[0].published_at.toISOString());
+      expect(res.body.data[0].published_at).toBe(mockWordSets[0].published_at.toISOString());
     });
 
     it('should handle errors', async () => {


### PR DESCRIPTION
Added pagination to the puzzles archive page and moved the "View All Puzzles" button above the "How to Play" section on the home page with responsive styling. Updated backend to support pagination parameters.

---
*PR created automatically by Jules for task [745913693782411871](https://jules.google.com/task/745913693782411871) started by @obasekietinosa*